### PR TITLE
Add Subnet-Based Location Setting

### DIFF
--- a/choose_location.js
+++ b/choose_location.js
@@ -3,18 +3,13 @@ var user_location = null;
 var msg = "Where are you working? Enter 'sherman' or 'library'.";
 
 function select(ips) {
-    console.log(ips);
+    for (var i = 0; i < ips.length; i++) {
+        console.log("IP: " + ips[i]);
 
-    for (var ip in ips) {
-        console.log("IP: " + ip);
-        if (!ips.hasOwnProperty(ip))
-            continue;
-        console.log("Tested!");
-
-        if (ip.startsWith("129.105.22")) {
+        if (ips[i].startsWith("129.105.22")) {
             user_location = "library";
             break;
-        } else if (ip.startsWith("129.105.188")) {
+        } else if (ips[i].startsWith("129.105.188")) {
             user_location = "sherman";
             break;
         }
@@ -63,11 +58,7 @@ function getLocalIPs(callback) {
     }, function onerror() {});
 }
 
-function eko(ips) {
-    console.log(ips);
-}
-
-getLocalIPs(eko);
+getLocalIPs(select);
 
 // save to chrome storage -- note this overwrites previous value,
 // which handles the user working in different locations

--- a/choose_location.js
+++ b/choose_location.js
@@ -1,14 +1,65 @@
 // ask user where they are, must be either "library" or "sherman"
-var user_location;
-var msg = "Where are you working? Enter 'sherman' or 'library'."
-while (true) {
-    user_location = window.prompt(msg);
-    if (user_location === "sherman" || user_location === "library") {
-        break;
-    } else {
-        msg = "Invalid location supplied. Enter 'sherman' or 'library'."
+var user_location = null;
+var msg = "Where are you working? Enter 'sherman' or 'library'.";
+
+function select(ips) {
+    for (var ip in ips) {
+        if (!ips.hasOwnProperty(ip))
+            continue;
+
+        if (ip.startsWith("129.105.22")) {
+            user_location = "library";
+            break;
+        } else if (ip.startsWith("129.105.188")) {
+            user_location = "sherman";
+            break;
+        }
+    }
+
+    if (user_location == null) {
+        while (true) {
+            user_location = window.prompt(msg);
+            if (user_location === "sherman" || user_location === "library") {
+                break;
+            } else {
+                msg = "Invalid location supplied. Enter 'sherman' or 'library'."
+            }
+        }
     }
 }
+
+// Taken from https://stackoverflow.com/questions/18572365/get-local-ip-of-a-device-in-chrome-extension
+function getLocalIPs(callback) {
+    var ips = [];
+
+    var RTCPeerConnection = window.RTCPeerConnection ||
+        window.webkitRTCPeerConnection || window.mozRTCPeerConnection;
+
+    var pc = new RTCPeerConnection({
+        // Don't specify any stun/turn servers, otherwise you will
+        // also find your public IP addresses.
+        iceServers: []
+    });
+    // Add a media line, this is needed to activate candidate gathering.
+    pc.createDataChannel('');
+
+    // onicecandidate is triggered whenever a candidate has been found.
+    pc.onicecandidate = function(e) {
+        if (!e.candidate) { // Candidate gathering completed.
+            pc.close();
+            callback(ips);
+            return;
+        }
+        var ip = /^candidate:.+ (\S+) \d+ typ/.exec(e.candidate.candidate)[1];
+        if (ips.indexOf(ip) == -1) // avoid duplicate entries (tcp/udp)
+            ips.push(ip);
+    };
+    pc.createOffer(function(sdp) {
+        pc.setLocalDescription(sdp);
+    }, function onerror() {});
+}
+
+getLocalIPs(select);
 
 // save to chrome storage -- note this overwrites previous value,
 // which handles the user working in different locations

--- a/choose_location.js
+++ b/choose_location.js
@@ -63,7 +63,11 @@ function getLocalIPs(callback) {
     }, function onerror() {});
 }
 
-getLocalIPs(select);
+function eko(ips) {
+    console.log(ips);
+}
+
+getLocalIPs(eko);
 
 // save to chrome storage -- note this overwrites previous value,
 // which handles the user working in different locations

--- a/choose_location.js
+++ b/choose_location.js
@@ -25,6 +25,14 @@ function select(ips) {
             }
         }
     }
+
+    // save to chrome storage -- note this overwrites previous value,
+    // which handles the user working in different locations
+    chrome.storage.local.set({
+        "location" : user_location
+    }, function(result) {
+        console.log("Set location to", user_location);
+    });
 }
 
 // Taken from https://stackoverflow.com/questions/18572365/get-local-ip-of-a-device-in-chrome-extension
@@ -60,10 +68,3 @@ function getLocalIPs(callback) {
 
 getLocalIPs(select);
 
-// save to chrome storage -- note this overwrites previous value,
-// which handles the user working in different locations
-chrome.storage.local.set({
-    "location" : user_location
-}, function(result) {
-    console.log("Set location to", user_location);
-});

--- a/choose_location.js
+++ b/choose_location.js
@@ -4,8 +4,10 @@ var msg = "Where are you working? Enter 'sherman' or 'library'.";
 
 function select(ips) {
     for (var ip in ips) {
+        console.log("IP: " + ip);
         if (!ips.hasOwnProperty(ip))
             continue;
+        console.log("Tested!");
 
         if (ip.startsWith("129.105.22")) {
             user_location = "library";

--- a/choose_location.js
+++ b/choose_location.js
@@ -3,6 +3,8 @@ var user_location = null;
 var msg = "Where are you working? Enter 'sherman' or 'library'.";
 
 function select(ips) {
+    console.log(ips);
+
     for (var ip in ips) {
         console.log("IP: " + ip);
         if (!ips.hasOwnProperty(ip))


### PR DESCRIPTION
Use WebRTC code (taken from someone's answer on Stack Overflow) to retrieve internal IP(s) on the machine, iterate over them, and check for IPs matching the library location subnet or the Sherman location subnet. The first matching IP is taken as the location. If no IPs match the location, the user is prompted for a location instead, as in the previous version.